### PR TITLE
Negotiate content type on post

### DIFF
--- a/lib/grape/jwt/authentication/jwt_handler.rb
+++ b/lib/grape/jwt/authentication/jwt_handler.rb
@@ -79,6 +79,12 @@ module Grape
           token
         end
 
+        def app_options
+          return @app.options if @app.instance_of?(Grape::Middleware::Formatter)
+          return @app.app.options if @app.respond_to?(:app) &&  @app.app&.instance_of?(Grape::Middleware::Formatter)
+          {}
+        end
+
         # Perform the authentication logic on the Rack compatible
         # interface.
         #
@@ -92,7 +98,7 @@ module Grape
           # responses on authentication errors. We want to be smarter
           # here and respond in the requested format on authentication
           # errors, that why we invoke the formatter middleware here.
-          Grape::Middleware::Formatter.new(->(_) {}).call(env)
+          Grape::Middleware::Formatter.new(->(_) {}, app_options).call(env)
 
           # Parse the JWT token and give it to the user defined block
           # for futher verification. The user given block MUST return

--- a/lib/grape/jwt/authentication/jwt_handler.rb
+++ b/lib/grape/jwt/authentication/jwt_handler.rb
@@ -88,7 +88,7 @@ module Grape
           # Unfortunately Grape's middleware stack orders the error
           # handling higher than the formatter. So when a error is
           # raised, the Rack env was not yet analysed and the content
-          # type not negotiated. This would result in allways-JSON
+          # type not negotiated. This would result in always-JSON
           # responses on authentication errors. We want to be smarter
           # here and respond in the requested format on authentication
           # errors, that why we invoke the formatter middleware here.

--- a/spec/grape/jwt/grape_usage_spec.rb
+++ b/spec/grape/jwt/grape_usage_spec.rb
@@ -31,6 +31,30 @@ module TestGlobalConfiguration
   end
 end
 
+module TestContentType
+  class API < Grape::API
+    version 'v1', using: :path
+
+    content_type :jsonapi, "application/vnd.api+json"
+    default_format :jsonapi
+    format :jsonapi
+
+
+    include Grape::Jwt::Authentication
+    auth :jwt, malformed: $custom_malformed_auth_handler,
+         failed: $custom_failed_auth_handler,
+         &$custom_authenticator
+
+
+    resource :test do
+      desc 'A simple GET endpoint which is JWT protected.'
+      post do
+        { test: true }
+      end
+    end
+  end
+end
+
 module TestLocalConfiguration
   class API < Grape::API
     version 'v1', using: :path
@@ -51,10 +75,6 @@ module TestLocalConfiguration
 end
 
 RSpec.shared_examples 'api' do
-  let(:malformed_token) { 'no.json.web.token' }
-  let(:invalid_token) { 'eyJ0eXAiOiJKV1QifQ.eyJ0ZXN0IjpmYWxzZX0.' }
-  let(:valid_token) { 'eyJ0eXAiOiJKV1QifQ.eyJ0ZXN0Ijp0cnVlfQ.' }
-
   it 'fails on missing authorization header' do
     get '/v1/test'
     expect(last_response.body).to \
@@ -84,6 +104,10 @@ end
 
 # rubocop:disable RSpec/DescribeClass because we test not a specific class
 RSpec.describe 'Grape usage' do
+  let(:valid_token) { 'eyJ0eXAiOiJKV1QifQ.eyJ0ZXN0Ijp0cnVlfQ.' }
+  let(:malformed_token) { 'no.json.web.token' }
+  let(:invalid_token) { 'eyJ0eXAiOiJKV1QifQ.eyJ0ZXN0IjpmYWxzZX0.' }
+
   include Rack::Test::Methods
 
   before { Grape::Jwt::Authentication.reset_configuration! }
@@ -106,5 +130,20 @@ RSpec.describe 'Grape usage' do
     let(:app) { TestLocalConfiguration::API }
 
     include_examples 'api'
+  end
+
+  context 'with a custom content type' do
+    let(:app) { TestContentType::API }
+
+    it 'succeeds on POST' do
+      header 'Authorization', "Bearer #{valid_token}"
+      header 'CONTENT_TYPE', 'application/vnd.api+json'
+      header 'HTTP_ACCEPT', 'application/vnd.api+json'
+
+      post '/v1/test',
+           params: {},
+           as: :json
+      expect(last_response.body).to be_eql('{"test":true}')
+    end
   end
 end


### PR DESCRIPTION
I ran into an error where the content type is not correctly passed through from the main Grape config on POST requests. This doesn't matter if using one of the default content types, but fails if it's a custom one.

This passes the options from the app to the formatter when it's called in the `JwtHandler`.