### PR TITLE
Added the parsed tokens to the Rack environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ flexible on the JWT verification level.
 - [Installation](#installation)
 - [Usage](#usage)
   - [Grape API](#grape-api)
+    - [Helpers](#helpers)
   - [Configuration](#configuration)
     - [Authenticator](#authenticator)
     - [Malformed token handling](#malformed-token-handling)
@@ -65,6 +66,42 @@ module UserApi
   class ApiV1 < Grape::API
     # All your fancy Grape API stuff [..]
     version 'v1', using: :path
+
+    # Enable JWT authentication on this API
+    include Grape::Jwt::Authentication
+    auth :jwt
+  end
+end
+```
+
+#### Helpers
+
+The inclusion of the `Grape::Jwt::Authentication` inserts some helpers to
+access the parsed and original JWT. This can be handy when you need to work
+with the JWT payload or perform some extra calculations with the expiration
+date of it.  The following example demonstrated the usage of the helpers.
+
+```ruby
+module UserApi
+  class ApiV1 < Grape::API
+    # All your fancy Grape API stuff [..]
+    version 'v1', using: :path
+
+    resource :payload do
+      desc 'A JWT payload echo service.'
+      get do
+        # The parsed JWT which has an accessible payload (RecursiveOpenStruct)
+        { payload: request_jwt.payload.to_h }
+      end
+    end
+
+    resource :token do
+      desc 'A JWT echo service.'
+      get do
+        # The original JWT parsed from the HTTP authorization header
+        { token: original_request_jwt }
+      end
+    end
 
     # Enable JWT authentication on this API
     include Grape::Jwt::Authentication
@@ -377,8 +414,8 @@ end
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run
-`rake spec` to run the tests. You can also run `bin/console` for an interactive
-prompt that will allow you to experiment.
+`bundle exec rake spec` to run the tests. You can also run `bin/console` for an
+interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To
 release a new version, update the version number in `version.rb`, and then run

--- a/grape-jwt-authentication.gemspec
+++ b/grape-jwt-authentication.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'grape/jwt/authentication/version'
 
@@ -22,14 +22,14 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'rack', '~> 2.0'
+  spec.add_development_dependency 'rack-test', '~> 0.8.2'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.15'
+  spec.add_development_dependency 'timecop', '~> 0.9.1'
   spec.add_development_dependency 'vcr', '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 3.1'
-  spec.add_development_dependency 'timecop', '~> 0.9.1'
-  spec.add_development_dependency 'rack', '~> 2.0'
-  spec.add_development_dependency 'rack-test', '~> 0.8.2'
 
   spec.add_runtime_dependency 'activesupport', '>= 3.2.0'
   spec.add_runtime_dependency 'grape', '~> 1.0'

--- a/lib/grape/jwt/authentication.rb
+++ b/lib/grape/jwt/authentication.rb
@@ -58,6 +58,27 @@ module Grape
         Grape::Middleware::Auth::Strategies.add(:jwt,
                                                 JwtHandler,
                                                 ->(opts) { [opts] })
+
+        helpers do
+          # Get the parsed JWT from the authorization header of the current
+          # request. You could use it to access the payload or the expiration
+          # date, etc inside your API definition. When the authenticator stated
+          # that the validation failed, then the parsed token is +nil+.
+          #
+          # @return [Grape::Jwt::Authentication::Jwt, nil] the parsed token
+          def request_jwt
+            env['grape_jwt_auth.parsed_token']
+          end
+
+          # Get the original JWT from the authorization header of the current
+          # request, without further changes. You could use it to display a
+          # custom error or to parse it differently.
+          #
+          # @return [String] the JWT from the authorization header
+          def original_request_jwt
+            env['grape_jwt_auth.original_token']
+          end
+        end
       end
     end
   end

--- a/lib/grape/jwt/authentication/jwt.rb
+++ b/lib/grape/jwt/authentication/jwt.rb
@@ -63,6 +63,7 @@ module Grape
         def expires_at
           exp = payload.exp
           return nil unless exp
+
           Time.zone.at(exp)
         end
 

--- a/lib/grape/jwt/authentication/rsa_public_key.rb
+++ b/lib/grape/jwt/authentication/rsa_public_key.rb
@@ -61,6 +61,7 @@ module Grape
         # @return [String] The encoded public key
         def fetch_encoded_key
           raise ArgumentError, 'No URL for RsaPublicKey configured' unless url
+
           if remote?
             HTTParty.get(url).body
           else

--- a/spec/grape/jwt/authentication/jwt_spec.rb
+++ b/spec/grape/jwt/authentication/jwt_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe Grape::Jwt::Authentication::Jwt do
 
   describe '#expires_at' do
     before { Timecop.freeze }
+
     after { Timecop.return }
 
     it 'exports the expiration date when set' do

--- a/spec/grape/jwt/grape_usage_spec.rb
+++ b/spec/grape/jwt/grape_usage_spec.rb
@@ -26,6 +26,20 @@ module TestGlobalConfiguration
       end
     end
 
+    resource :payload do
+      desc 'A JWT payload echo service.'
+      get do
+        { payload: request_jwt.payload.to_h }
+      end
+    end
+
+    resource :token do
+      desc 'A JWT echo service.'
+      get do
+        { token: original_request_jwt }
+      end
+    end
+
     include Grape::Jwt::Authentication
     auth :jwt
   end
@@ -40,6 +54,20 @@ module TestLocalConfiguration
       desc 'A simple GET endpoint which is JWT protected.'
       get do
         { test: true }
+      end
+    end
+
+    resource :payload do
+      desc 'A JWT payload echo service.'
+      get do
+        { payload: request_jwt.payload.to_h }
+      end
+    end
+
+    resource :token do
+      desc 'A JWT echo service.'
+      get do
+        { token: original_request_jwt }
       end
     end
 
@@ -80,6 +108,24 @@ RSpec.shared_examples 'api' do
     get '/v1/test'
     expect(last_response.body).to be_eql('{"test":true}')
   end
+
+  describe 'helpers' do
+    describe '#original_request_jwt' do
+      it 'echos the JWT' do
+        header 'Authorization', "Bearer #{valid_token}"
+        get '/v1/token'
+        expect(last_response.body).to be_eql(%({"token":"#{valid_token}"}))
+      end
+    end
+
+    describe '#request_jwt' do
+      it 'echos the JWT payload' do
+        header 'Authorization', "Bearer #{valid_token}"
+        get '/v1/payload'
+        expect(last_response.body).to be_eql(%({"payload":{"test":true}}))
+      end
+    end
+  end
 end
 
 # rubocop:disable RSpec/DescribeClass because we test not a specific class
@@ -108,3 +154,5 @@ RSpec.describe 'Grape usage' do
     include_examples 'api'
   end
 end
+# rubocop:enable RSpec/DescribeClass
+# rubocop:enable Style/GlobalVars

--- a/spec/grape/jwt/rack_usage_spec.rb
+++ b/spec/grape/jwt/rack_usage_spec.rb
@@ -58,3 +58,4 @@ RSpec.describe 'Rack usage' do
     expect(last_response.body).to match(/Lobstericious!/)
   end
 end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/grape/jwt/rsa_opinionated_spec.rb
+++ b/spec/grape/jwt/rsa_opinionated_spec.rb
@@ -105,3 +105,4 @@ RSpec.describe 'RSA optinionated usage' do
     expect(last_response.body).to be_eql('{"test":true}')
   end
 end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
This update ships the injection of the parsed and the original JWT into the
Rack environment. Furthermore two new Grape helper methods were introduced to
access these tokens from a API specification for further usage. (`request_jwt`
and `original_request_jwt`)

Signed-off-by: Hermann Mayer <hermann.mayer92@gmail.com>