### PR TITLE
Case insensitive header check and bump gemspec dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### next
 
+* Implemented case-insensitive header value checks for Grape 2.0.0+ compatibility, aligning with HTTP/2+ semantics (#11)
 * Moved the development dependencies from the gemspec to the Gemfile (#10)
 
 ### 2.2.0

--- a/grape-jwt-authentication.gemspec
+++ b/grape-jwt-authentication.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5'
 
   spec.add_runtime_dependency 'activesupport', '>= 5.2'
-  spec.add_runtime_dependency 'grape', '~> 1.0'
+  spec.add_runtime_dependency 'grape', '>= 1.0', '< 3.0'
   spec.add_runtime_dependency 'httparty', '>= 0.21'
   spec.add_runtime_dependency 'jwt', '~> 2.6'
   spec.add_runtime_dependency 'keyless', '~> 1.1'

--- a/lib/grape/jwt/authentication/jwt_handler.rb
+++ b/lib/grape/jwt/authentication/jwt_handler.rb
@@ -115,7 +115,9 @@ module Grape
           Grape::Middleware::Formatter.new(->(_) {}).call(env)
 
           # Parse the JWT token from the request headers.
-          token = parse_token(env['HTTP_AUTHORIZATION'])
+          # Downcase the header keys to account for HTTP/2+ semantics in Grape 2.0.0+
+          lowercase_env = env.transform_keys(&:downcase)
+          token = parse_token(lowercase_env['http_authorization'])
 
           # Inject the parsed token to the Rack environment.
           inject_token_into_env(env, token)

--- a/spec/grape/jwt/grape_usage_spec.rb
+++ b/spec/grape/jwt/grape_usage_spec.rb
@@ -110,6 +110,11 @@ RSpec.shared_examples 'api' do
     expect(last_response.body).to be_eql('{"test":true}')
   end
 
+  it 'succeeds on a lowercase authorization header' do
+    get '/v1/test', {}, {'http_authorization' => "Bearer #{valid_token}"}
+    expect(last_response.body).to be_eql('{"test":true}')
+  end
+
   describe 'helpers' do
     describe '#original_request_jwt' do
       it 'echos the JWT' do


### PR DESCRIPTION
Implementing case-insensitive header value checks and adjusting dependencies to support Grape 2.0.0+